### PR TITLE
Factored out fin-related things, added ordered types for fin

### DIFF
--- a/Fin.v
+++ b/Fin.v
@@ -1,0 +1,236 @@
+Require Import Arith.
+Require Import Omega.
+Require Import NPeano.
+Require Import List.
+Import ListNotations.
+Require Import StructTact.StructTactics.
+Require Import StructTact.Util.
+Require Import OrderedType.
+
+Set Implicit Arguments.
+
+Fixpoint fin (n : nat) : Type :=
+  match n with
+    | 0 => False
+    | S n' => option (fin n')
+  end.
+
+Lemma fin_eq_dec : forall n (a b : fin n), {a = b} + {a <> b}.
+Proof.
+  induction n.
+  - auto.
+  - intros. destruct a, b; intuition (auto; try discriminate).
+    specialize (IHn f f0). intuition congruence.
+Qed.
+
+Fixpoint all_fin (n : nat) : list (fin n) :=
+  match n with
+    | 0 => []
+    | S n' => None :: map (fun x => Some x) (all_fin n')
+  end.
+
+Lemma all_fin_all :
+  forall n (x : fin n),
+    In x (all_fin n).
+Proof.
+  induction n; intros.
+  - solve_by_inversion.
+  - simpl in *. destruct x; auto using in_map.
+Qed.
+
+Lemma all_fin_NoDup :
+  forall n,
+    NoDup (all_fin n).
+Proof.
+  induction n; intros; simpl; constructor.
+  - intro. apply in_map_iff in H. firstorder. discriminate.
+  - apply NoDup_map_injective; auto. congruence.
+Qed.
+
+Fixpoint fin_to_nat {n : nat} : fin n -> nat :=
+  match n with
+  | 0 => fun x : fin 0 => match x with end
+  | S n' => fun x : fin (S n') =>
+             match x with
+             | None => 0
+             | Some y => S (fin_to_nat y)
+             end
+  end.
+
+Definition fin_lt {n : nat} (a b : fin n) : Prop := lt (fin_to_nat a) (fin_to_nat b).
+
+Lemma fin_lt_Some_elim :
+  forall n (a b : fin n), @fin_lt (S n) (Some a) (Some b) -> fin_lt a b.
+Proof.
+  intros.
+  unfold fin_lt. simpl.
+  intuition.
+Qed.
+
+Lemma fin_lt_Some_intro :
+  forall n (a b : fin n), fin_lt a b -> @fin_lt (S n) (Some a) (Some b).
+Proof.
+  intros.
+  unfold fin_lt. simpl.
+  intuition.
+Qed.
+
+Lemma None_lt_Some :
+  forall n (x : fin n),
+    @fin_lt (S n) None (Some x).
+Proof.
+  unfold fin_lt. simpl. auto with *.
+Qed.
+
+Lemma fin_lt_trans : forall n (x y z : fin n),
+    fin_lt x y -> fin_lt y z -> fin_lt x z.
+Proof.
+  induction n; intros.
+  - destruct x.
+  - destruct x, y, z; simpl in *;
+    repeat match goal with
+    | [ H : fin_lt (Some _) (Some _) |- _ ] => apply fin_lt_Some_elim in H
+    | [ |- fin_lt (Some _) (Some _) ] => apply fin_lt_Some_intro
+    end; eauto using None_lt_Some; solve_by_inversion.
+Qed.
+
+Lemma fin_lt_not_eq : forall n (x y : fin n), fin_lt x y -> x <> y.
+Proof.
+  induction n; intros.
+  - destruct x.
+  - destruct x, y;
+    repeat match goal with
+    | [ H : fin_lt (Some _) (Some _) |- _ ] => apply fin_lt_Some_elim in H
+    | [ |- fin_lt (Some _) (Some _) ] => apply fin_lt_Some_intro
+    end; try congruence.
+    + specialize (IHn f f0). concludes. congruence.
+    + solve_by_inversion.
+Qed.
+
+Fixpoint fin_compare (n : nat) : forall (x y : fin n), Compare fin_lt eq x y :=
+  match n with
+  | 0 => fun x y : fin 0 => match x with end
+  | S n' => fun x y : fin (S n') =>
+             match x, y with
+             | Some x', Some y' =>
+               match fin_compare n' x' y' with
+               | LT pf => LT (fin_lt_Some_intro pf)
+               | EQ pf => EQ (f_equal _ pf)
+               | GT pf => GT (fin_lt_Some_intro pf)
+               end
+             | Some x', None => GT (None_lt_Some n' x')
+             | None, Some y' => LT (None_lt_Some n' y')
+             | None, None => EQ eq_refl
+             end
+  end.
+
+Module Type NatValue.
+  Parameter n : nat.
+End NatValue.
+
+Module fin_OT_compat (N : NatValue) <: OrderedType.
+  Definition t := fin N.n.
+  Definition eq : t -> t -> Prop := eq.
+  Definition lt : t -> t -> Prop := fin_lt.
+  Definition eq_refl : forall x : t, eq x x := @eq_refl _.
+  Definition eq_sym : forall x y: t, eq x y -> eq y x := @eq_sym _.
+  Definition eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z := @eq_trans _.
+  Definition lt_trans : forall x y z : t, lt x y -> lt y z -> lt x z := @fin_lt_trans N.n.
+  Definition lt_not_eq : forall x y : t, lt x y -> ~ eq x y := @fin_lt_not_eq N.n. 
+  Definition compare : forall x y : t, Compare lt eq x y := fin_compare N.n.
+  Definition eq_dec : forall x y : t, {eq x y} + {~ eq x y} := fin_eq_dec N.n.
+End fin_OT_compat.
+
+Require Import Orders.
+
+Lemma fin_lt_irrefl : forall n, Irreflexive (@fin_lt n).
+Proof.
+  intros.
+  unfold Irreflexive.
+  unfold complement.
+  unfold Reflexive.
+  unfold fin_lt.
+  intros x H.
+  contradict H.
+  auto with arith.
+Qed.
+
+Lemma fin_lt_strorder : forall n, StrictOrder (@fin_lt n).
+Proof.
+  intros.
+  apply (Build_StrictOrder _ (@fin_lt_irrefl n) (@fin_lt_trans n)).
+Qed.
+
+Lemma fin_lt_lt_compat : forall n, Proper (eq ==> eq ==> iff) (@fin_lt n).
+Proof.
+  intros.
+  split.
+  - intros.
+    rewrite H in H1.
+    rewrite H0 in H1.
+    assumption.
+  - intros.
+    rewrite H.
+    rewrite H0.
+    assumption.
+Qed.
+
+Fixpoint fin_comparison_dec (n : nat) : forall (x y : fin n), { cmp : comparison | CompSpec eq fin_lt x y cmp }.
+  case n.
+  - intros; case x.
+  - intros.
+    case x; case y; intros.
+    * case (fin_comparison_dec n0 f f0).
+      intros x0.
+      case x0.
+      + exists Eq.
+        apply CompEq.
+        apply f_equal.
+        inversion c.
+        rewrite H; trivial.
+      + exists Gt.
+        apply CompGt.
+        apply fin_lt_Some_intro.
+        inversion c.
+        assumption.
+      + exists Lt.
+        apply CompLt.
+        apply fin_lt_Some_intro.
+        inversion c.
+        assumption.
+    * exists Gt.
+      apply CompGt.
+      apply None_lt_Some.
+    * exists Lt.
+      apply CompLt.
+      apply None_lt_Some.
+    * exists Eq.
+      apply CompEq.
+      apply eq_refl.
+Defined.
+
+Definition fin_comparison (n : nat) (x y : fin n) : comparison :=
+  match fin_comparison_dec n x y with
+  | exist _ cmp _ => cmp
+  end.
+
+Lemma fin_compare_spec : forall (n : nat) (x y : fin n), CompSpec eq fin_lt x y (fin_comparison n x y).
+Proof.
+  intros.
+  unfold fin_comparison.
+  case (fin_comparison_dec _ _).
+  intros.
+  assumption.
+Qed.
+
+Module fin_OT (N : NatValue) <: OrderedType.
+  Definition t := fin N.n.
+  Definition eq := eq (A := fin N.n).
+  Definition eq_equiv := eq_equivalence (A := fin N.n).
+  Definition lt := fin_lt (n := N.n).
+  Definition lt_strorder := fin_lt_strorder N.n.
+  Definition lt_compat := fin_lt_lt_compat N.n.
+  Definition compare := fin_comparison N.n.
+  Definition compare_spec := fin_compare_spec N.n.
+  Definition eq_dec := fin_eq_dec N.n.
+End fin_OT.

--- a/Util.v
+++ b/Util.v
@@ -714,43 +714,6 @@ Proof.
       auto with arith.
 Qed.
 
-Fixpoint fin (n : nat) : Type :=
-  match n with
-    | 0 => False
-    | S n' => option (fin n')
-  end.
-
-Lemma fin_eq_dec : forall n (a b : fin n), {a = b} + {a <> b}.
-Proof.
-  induction n.
-  - auto.
-  - intros. destruct a, b; intuition (auto; try discriminate).
-    specialize (IHn f f0). intuition congruence.
-Qed.
-
-Fixpoint all_fin (n : nat) : list (fin n) :=
-  match n with
-    | 0 => []
-    | S n' => None :: map (fun x => Some x) (all_fin n')
-  end.
-
-Lemma all_fin_all :
-  forall n (x : fin n),
-    In x (all_fin n).
-Proof.
-  induction n; intros.
-  - solve_by_inversion.
-  - simpl in *. destruct x; auto using in_map.
-Qed.
-
-Lemma all_fin_NoDup :
-  forall n,
-    NoDup (all_fin n).
-Proof.
-  induction n; intros; simpl; constructor.
-  - intro. apply in_map_iff in H. firstorder. discriminate.
-  - apply NoDup_map_injective; auto. congruence.
-Qed.
 
 Lemma or_false :
   forall P : Prop, P -> (P \/ False).


### PR DESCRIPTION
I believe fin should be considered a datatype of its own and not be mixed up with miscellaneous list lemmas. Therefore, I factored out fin-related definitions and lemmas to their own file (Fin.v). I also added, with the help of James Wilcox, ordered types for fin, so that fin can be used in FMap and MSet modules. This allows Verdi protocols to use finite maps and sets on names in node data, which is common in, e.g., routing and aggregation protocols.

Note that the "Require Import Orders" in the middle of the file is necessary to be able to define ordered types for both the legacy OrderedType (for FMap) and the new OrderedType (for MSet).

To make Verdi itself compatible with the new structure, there needs to be some "Require Import StructTac.Fin" added (11 of them, in fact). I can do a separate Verdi pull request for that if you want.
