### PR TITLE
fix injc bug, fix spelling in aggressive_rewrite_goal

### DIFF
--- a/StructTactics.v
+++ b/StructTactics.v
@@ -365,7 +365,7 @@ Ltac find_false :=
   end.
 
 Ltac injc H :=
-  injection H; clear H; intro; subst_max.
+  injection H; clear H; intros; subst_max.
 
 Ltac find_injection :=
   match goal with
@@ -377,7 +377,7 @@ Ltac find_injection :=
     | [ H : ?X _ = ?X _ |- _ ] => injc H
   end.
 
-Ltac aggresive_rewrite_goal :=
+Ltac aggressive_rewrite_goal :=
   match goal with H : _ |- _ => rewrite H end.
 
 Ltac break_exists_name x :=


### PR DESCRIPTION
The find_injection tactic did not work properly for me - there were equalities left in some goals. Turns out the problem was due to the use of "intro" instead of "intros" in the injc tactic. Also, I fixed the spelling of another tactic. 
