### PR TITLE
Move a_equiv from Verdi to StructTact

### DIFF
--- a/Util.v
+++ b/Util.v
@@ -1089,6 +1089,167 @@ Section assoc.
   Qed.
 End assoc.
 
+Section assoc_lemmas.
+  Variable K V : Type.
+  Variable K_eq_dec : forall k k' : K, {k = k'} + {k <> k'}.
+
+  Lemma assoc_assoc_default:
+    forall l k (v : V) d,
+      assoc K_eq_dec l k = Some v ->
+      assoc_default K_eq_dec l k d = v.
+  Proof.
+    intros. unfold assoc_default.
+    break_match; congruence.
+  Qed.
+
+  Lemma assoc_assoc_default_missing:
+    forall (l : list (K * V)) k d,
+      assoc K_eq_dec l k = None ->
+      assoc_default K_eq_dec l k d = d.
+  Proof.
+    intros. unfold assoc_default.
+    break_match; congruence.
+  Qed.
+
+  Lemma assoc_set_same :
+    forall (l : list (K * V)) k v,
+      assoc K_eq_dec l k = Some v ->
+      assoc_set K_eq_dec l k v = l.
+  Proof.
+    intros. induction l; simpl in *; auto; try congruence.
+    repeat break_match; simpl in *; intuition.
+    - subst. find_inversion. auto.
+    - repeat find_rewrite. auto.
+  Qed.
+
+  Lemma assoc_default_assoc_set :
+    forall l (k : K) (v : V) d,
+      assoc_default K_eq_dec (assoc_set K_eq_dec l k v) k d = v.
+  Proof.
+    intros. unfold assoc_default.
+    rewrite get_set_same. auto.
+  Qed.
+
+  Lemma assoc_set_assoc_set_same :
+    forall l (k : K) (v : V) v',
+      assoc_set K_eq_dec (assoc_set K_eq_dec l k v) k v' = assoc_set K_eq_dec l k v'.
+  Proof.
+    induction l; intros; simpl in *; repeat break_match; simpl in *; subst; try congruence; eauto;
+break_if; congruence.
+  Qed.
+
+  Definition a_equiv (l1 : list (K * V)) l2 :=
+    forall k,
+      assoc K_eq_dec l1 k = assoc K_eq_dec l2 k.
+
+  Lemma a_equiv_refl :
+    forall l,
+      a_equiv l l.
+  Proof.
+    intros. unfold a_equiv. auto.
+  Qed.
+
+  Lemma a_equiv_sym :
+    forall l l',
+      a_equiv l l' ->
+      a_equiv l' l.
+  Proof.
+    unfold a_equiv. intros. auto.
+  Qed.
+
+  Lemma a_equiv_trans :
+    forall l l' l'',
+      a_equiv l l' ->
+      a_equiv l' l'' ->
+      a_equiv l l''.
+  Proof.
+    unfold a_equiv in *.
+    intros. repeat find_higher_order_rewrite.
+    auto.
+  Qed.
+
+  Ltac assoc_destruct :=
+    match goal with
+    | [ |- context [assoc _ (assoc_set _ _ ?k0' _) ?k0 ] ] =>
+      destruct (K_eq_dec k0 k0'); [subst k0'; rewrite get_set_same with (k := k0)|
+                                   rewrite get_set_diff with (k' := k0) by auto]
+    end.
+
+  Ltac assoc_rewrite :=
+    match goal with
+    | [  |- context [assoc _ (assoc_set _ _ ?k0' _) ?k0 ] ] =>
+      first [rewrite get_set_same with (k := k0) by auto |
+             rewrite get_set_diff with (k' := k0) by auto ]
+    end.
+
+  Lemma assoc_set_assoc_set_diff :
+    forall l (k : K) (v : V) k' v',
+      k <> k' ->
+      a_equiv (assoc_set K_eq_dec (assoc_set K_eq_dec l k v) k' v')
+              (assoc_set K_eq_dec (assoc_set K_eq_dec l k' v') k v).
+  Proof.
+    unfold a_equiv.
+    intros.
+    assoc_destruct.
+    - now repeat assoc_rewrite.
+    - assoc_destruct.
+      + now repeat assoc_rewrite.
+      + now repeat assoc_rewrite.
+  Qed.
+
+  Lemma a_equiv_nil :
+    forall l,
+      a_equiv l [] ->
+      l = [].
+  Proof.
+    intros.
+    destruct l; auto.
+    unfold a_equiv in *. simpl in *.
+    destruct p.
+    specialize (H k).
+    break_if; try congruence.
+  Qed.
+
+  Lemma assoc_set_a_equiv :
+    forall l l' (k : K) (v : V),
+      a_equiv l l' ->
+      a_equiv (assoc_set K_eq_dec l k v) (assoc_set K_eq_dec l' k v).
+  Proof.
+    unfold a_equiv.
+    intros.
+    assoc_destruct; assoc_rewrite; auto.
+  Qed.
+
+  Lemma assoc_default_a_equiv :
+    forall l l' (k : K) (v : V),
+      a_equiv l l' ->
+      assoc_default K_eq_dec l k v = assoc_default K_eq_dec l' k v.
+  Proof.
+    intros. unfold a_equiv, assoc_default in *.
+    find_higher_order_rewrite.
+    auto.
+  Qed.
+
+  Lemma assoc_a_equiv :
+    forall l l' (k : K),
+      a_equiv l l' ->
+      assoc K_eq_dec l k = assoc K_eq_dec l' k.
+  Proof.
+    unfold a_equiv.
+    auto.
+  Qed.
+
+  Lemma assoc_default_assoc_set_diff :
+    forall (l : list (K * V)) k v k' d,
+      k <> k' ->
+      assoc_default K_eq_dec (assoc_set K_eq_dec l k' v) k d =
+      assoc_default K_eq_dec l k d.
+  Proof.
+    intros. unfold assoc_default. rewrite get_set_diff; auto.
+  Qed.
+End assoc_lemmas.
+Arguments a_equiv {_} {_} _ _ _.
+
 Fixpoint before {A: Type} (x : A) y l : Prop :=
   match l with
     | [] => False


### PR DESCRIPTION
I need this definition and related lemmas in another project. I have manually checked that Verdi builds with this change, but I have not checked other StructTact dependencies. We should really set up a way to do that automatically.
