### PR TITLE
add `break_and_goal` tactic

### DIFF
--- a/StructTactics.v
+++ b/StructTactics.v
@@ -80,6 +80,11 @@ Ltac break_and :=
            | [H : _ /\ _ |- _ ] => destruct H
          end.
 
+Ltac break_and_goal :=
+    repeat match goal with
+             | [ |- _ /\ _ ] => split
+           end.
+
 Ltac solve_by_inversion' tac :=
   match goal with
     | [H : _ |- _] => solve [inv H; tac]


### PR DESCRIPTION
If you have something like `P x` that's defined as a conjunction `P x := A x /\ B x` in a goal like `P x /\ Q /\ R y` and you do `repeat split`, you don't get three subgoals like you might want. This is because `split` will break `P x` into its constituent parts, and it's a problem if you have lemmas about `P x` that you want to use.

This new tactic splits the goal only at visible conjunctions, avoiding the issues introduced by a plain `repeat split`.
