### PR TITLE
Fix harmful contexts in do_bool

### DIFF
--- a/BoolUtil.v
+++ b/BoolUtil.v
@@ -42,10 +42,10 @@ Ltac do_bool :=
     | [ H : PeanoNat.Nat.ltb _ _ = false |- _ ] => apply ltb_false_le in H
     | [ H : leb _ _ = true |- _ ] => apply leb_true_le in H
     | [ H : leb _ _ = false |- _ ] => apply leb_false_lt in H
-    | [ |- context [ andb _ _ ] ] => apply Bool.andb_true_iff
-    | [ |- context [ andb _ _ ] ] => apply Bool.andb_false_iff
-    | [ |- context [ leb _ _ ] ] => apply leb_correct
-    | [ |- context [ _ <> false ] ] => apply Bool.not_false_iff_true
+    | [ |- andb _ _ = true ]=> apply Bool.andb_true_iff
+    | [ |- andb _ _ = false ] => apply Bool.andb_false_iff
+    | [ |- leb _ _ = true ] => apply leb_correct
+    | [ |-  _ <> false ] => apply Bool.not_false_iff_true
     | [ |- beq_nat _ _ = false ] => apply beq_nat_false_iff
     | [ |- beq_nat _ _ = true ] => apply beq_nat_true_iff
   end.


### PR DESCRIPTION
The current implementation of `do_bool` breaks whenever one of the contextual patterns matches a proper subterm in the goal, since the lemma applied on the RHS does not actually unify in that case. This can cause the tactic to loop.

This fix is unlikely to break backwards compatibility since the tactic was completely broken in these cases. I have manually checked that uwplse/verdi:master builds with this change.
