### PR TITLE
added "Proof using" in lemmas inside sections to enable asynchronous processing

### DIFF
--- a/Assoc.v
+++ b/Assoc.v
@@ -47,7 +47,7 @@ Section assoc.
   Lemma get_set_same :
     forall k v l,
       assoc (assoc_set l k v) k = Some v.
-  Proof.
+  Proof using.
     induction l; intros; simpl; repeat (break_match; simpl); subst; congruence.
   Qed.
 
@@ -55,7 +55,7 @@ Section assoc.
     forall k k' v l,
       k = k' ->
       assoc (assoc_set l k v) k' = Some v.
-  Proof.
+  Proof using.
     intros. subst. auto using get_set_same.
   Qed.
 
@@ -63,7 +63,7 @@ Section assoc.
     forall k k' v l,
       k <> k' ->
       assoc (assoc_set l k v) k' = assoc l k'.
-  Proof.
+  Proof using.
     induction l; intros; simpl; repeat (break_match; simpl); subst; try congruence; auto.
   Qed.
 
@@ -71,7 +71,7 @@ Section assoc.
     forall k l,
       ~ In k (map (@fst _ _) l) ->
       assoc l k = None.
-  Proof.
+  Proof using.
     intros.
     induction l.
     - auto.
@@ -82,7 +82,7 @@ Section assoc.
   Lemma get_del_same :
     forall k l,
       assoc (assoc_del l k) k = None.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *.
     - auto.
     - repeat break_match; subst; simpl in *; auto.
@@ -93,7 +93,7 @@ Section assoc.
     forall k k' l,
       k <> k' ->
       assoc (assoc_del l k') k = assoc l k.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *.
     - auto.
     - repeat (break_match; simpl); subst; try congruence; auto.
@@ -103,7 +103,7 @@ Section assoc.
     forall (k k' : K) (v : V) l d,
       k <> k' ->
       assoc_default (assoc_set l k v) k' d = assoc_default l k' d.
-  Proof.
+  Proof using.
     unfold assoc_default.
     intros.
     repeat break_match; auto;
@@ -113,7 +113,7 @@ Section assoc.
   Lemma get_set_same_default :
     forall (k : K) (v : V) l d,
       assoc_default (assoc_set l k v) k d = v.
-  Proof.
+  Proof using.
     unfold assoc_default.
     intros.
     repeat break_match; auto;
@@ -124,7 +124,7 @@ Section assoc.
     forall l k (v : V) d,
       assoc l k = Some v ->
       assoc_default l k d = v.
-  Proof.
+  Proof using.
     intros. unfold assoc_default.
     break_match; congruence.
   Qed.
@@ -133,7 +133,7 @@ Section assoc.
     forall (l : list (K * V)) k d,
       assoc l k = None ->
       assoc_default l k d = d.
-  Proof.
+  Proof using.
     intros. unfold assoc_default.
     break_match; congruence.
   Qed.
@@ -142,7 +142,7 @@ Section assoc.
     forall (l : list (K * V)) k v,
       assoc l k = Some v ->
       assoc_set l k v = l.
-  Proof.
+  Proof using.
     intros. induction l; simpl in *; auto; try congruence.
     repeat break_match; simpl in *; intuition.
     - subst. find_inversion. auto.
@@ -152,7 +152,7 @@ Section assoc.
   Lemma assoc_default_assoc_set :
     forall l (k : K) (v : V) d,
       assoc_default (assoc_set l k v) k d = v.
-  Proof.
+  Proof using.
     intros. unfold assoc_default.
     rewrite get_set_same. auto.
   Qed.
@@ -160,7 +160,7 @@ Section assoc.
   Lemma assoc_set_assoc_set_same :
     forall l (k : K) (v : V) v',
       assoc_set (assoc_set l k v) k v' = assoc_set l k v'.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; repeat break_match; simpl in *; subst; try congruence; eauto;
 break_if; congruence.
   Qed.
@@ -172,7 +172,7 @@ break_if; congruence.
   Lemma a_equiv_refl :
     forall l,
       a_equiv l l.
-  Proof.
+  Proof using.
     intros. unfold a_equiv. auto.
   Qed.
 
@@ -180,7 +180,7 @@ break_if; congruence.
     forall l l',
       a_equiv l l' ->
       a_equiv l' l.
-  Proof.
+  Proof using.
     unfold a_equiv. intros. auto.
   Qed.
 
@@ -189,7 +189,7 @@ break_if; congruence.
       a_equiv l l' ->
       a_equiv l' l'' ->
       a_equiv l l''.
-  Proof.
+  Proof using.
     unfold a_equiv in *.
     intros. repeat find_higher_order_rewrite.
     auto.
@@ -214,7 +214,7 @@ break_if; congruence.
       k <> k' ->
       a_equiv (assoc_set (assoc_set l k v) k' v')
               (assoc_set (assoc_set l k' v') k v).
-  Proof.
+  Proof using.
     unfold a_equiv.
     intros.
     assoc_destruct.
@@ -228,7 +228,7 @@ break_if; congruence.
     forall l,
       a_equiv l [] ->
       l = [].
-  Proof.
+  Proof using.
     intros.
     destruct l; auto.
     unfold a_equiv in *. simpl in *.
@@ -241,7 +241,7 @@ break_if; congruence.
     forall l l' (k : K) (v : V),
       a_equiv l l' ->
       a_equiv (assoc_set l k v) (assoc_set l' k v).
-  Proof.
+  Proof using.
     unfold a_equiv.
     intros.
     assoc_destruct; assoc_rewrite; auto.
@@ -251,7 +251,7 @@ break_if; congruence.
     forall l l' (k : K) (v : V),
       a_equiv l l' ->
       assoc_default l k v = assoc_default l' k v.
-  Proof.
+  Proof using.
     intros. unfold a_equiv, assoc_default in *.
     find_higher_order_rewrite.
     auto.
@@ -261,7 +261,7 @@ break_if; congruence.
     forall l l' (k : K),
       a_equiv l l' ->
       assoc l k = assoc l' k.
-  Proof.
+  Proof using.
     unfold a_equiv.
     auto.
   Qed.
@@ -271,7 +271,7 @@ break_if; congruence.
       k <> k' ->
       assoc_default (assoc_set l k' v) k d =
       assoc_default l k d.
-  Proof.
+  Proof using.
     intros. unfold assoc_default. rewrite get_set_diff; auto.
   Qed.
 End assoc.

--- a/Before.v
+++ b/Before.v
@@ -27,7 +27,7 @@ Section before.
     forall x y l,
       before (A:=A) x y l ->
       In x l.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition.
   Qed.
 
@@ -39,7 +39,7 @@ Section before.
       In y l ->
       exists xs ys zs,
         l = xs ++ x :: ys ++ y :: zs.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition; subst; try congruence.
     - exists nil. simpl. find_apply_lem_hyp in_split. break_exists. subst. eauto.
     - exists nil. simpl. find_apply_lem_hyp in_split. break_exists. subst. eauto.
@@ -53,14 +53,14 @@ Section before.
       In(A:=A) x xs ->
       (~ In y xs) ->
       before x y (xs ++ y :: ys).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition.
   Qed.
 
   Definition before_func_dec :
     forall f g (l : list A),
       {before_func f g l} + {~ before_func f g l}.
-  Proof.
+  Proof using.
     intros. induction l; simpl in *.
     - intuition.
     - destruct (f a); destruct (g a); intuition.
@@ -70,7 +70,7 @@ Section before.
     forall f g l x,
       before_func (A := A) f g l ->
       before_func f g (l ++ x).
-  Proof.
+  Proof using.
     intros. induction l; simpl in *; intuition.
   Qed.
 
@@ -80,7 +80,7 @@ Section before.
       b <> x ->
       b <> y ->
       before a b (xs ++ x :: ys ++ y :: zs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition.
     induction ys; intros; simpl in *; intuition.
   Qed.
@@ -90,7 +90,7 @@ Section before.
       before(A:=A) a b (xs ++ zs) ->
       b <> y ->
       before a b (xs ++ y :: zs).
-  Proof.
+  Proof using.
     intros.
     induction xs; intros; simpl in *; intuition.
   Qed.
@@ -101,7 +101,7 @@ Section before.
       a <> x ->
       a <> y ->
       before a b (xs ++ ys ++ zs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition; try congruence; eauto.
     induction ys; intros; simpl in *; intuition; try congruence.
   Qed.
@@ -111,7 +111,7 @@ Section before.
       before(A:=A) a b (xs ++ y :: zs) ->
       a <> y ->
       before a b (xs ++ zs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition; try congruence; eauto.
   Qed.
 
@@ -120,7 +120,7 @@ Section before.
       before (A := A) x y (remove dec y' l) ->
       y <> y' ->
       before x y l.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition.
     break_if; subst; simpl in *; intuition eauto.
   Qed.
@@ -130,7 +130,7 @@ Section before.
       before x y l ->
       x <> x' ->
       before x y (remove dec x' l).
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition;
       break_if; subst; simpl in *; intuition eauto.
   Qed.
@@ -140,7 +140,7 @@ Section before.
       before (A := A) x y (l' ++ l) ->
       ~ In x l' ->
       before (A := A) x y l.
-  Proof.
+  Proof using.
     induction l'; intros; simpl in *; intuition.
   Qed.
 
@@ -149,7 +149,7 @@ Section before.
       before (A := A) x y l ->
       ~ In y l' ->
       before (A := A) x y (l' ++ l).
-  Proof.
+  Proof using.
     induction l'; intros; simpl in *; intuition.
   Qed.
 
@@ -158,7 +158,7 @@ Section before.
       before (A := A) x y l ->
       before y x l ->
       x = y.
-  Proof.
+  Proof using.
     intros.
     induction l; simpl in *; intuition; congruence.
   Qed.

--- a/Dedup.v
+++ b/Dedup.v
@@ -22,7 +22,7 @@ Section dedup.
 
   Lemma dedup_eliminates_duplicates : forall (a : A) b c,
       (dedup (a :: b ++ a :: c) = dedup (b ++ a :: c)).
-  Proof.
+  Proof using.
     intros. simpl in *.
     break_match.
     + auto.
@@ -32,7 +32,7 @@ Section dedup.
   Lemma dedup_In : forall (x : A) xs,
       In x xs ->
       In x (dedup xs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *.
     - intuition.
     - break_if; intuition; subst; simpl; auto.
@@ -42,7 +42,7 @@ Section dedup.
     forall xs (p : A) ys,
       pred p = false ->
       filter pred (dedup (xs ++ ys)) = filter pred (dedup (xs ++ p :: ys)).
-  Proof.
+  Proof using.
     intros.
     induction xs; simpl; repeat (break_match; simpl);
       auto using f_equal2; try discriminate.
@@ -54,7 +54,7 @@ Section dedup.
   Lemma dedup_app : forall (xs ys : list A),
       (forall x y, In x xs -> In y ys -> x <> y) ->
       dedup (xs ++ ys) = dedup xs ++ dedup ys.
-  Proof.
+  Proof using.
     intros. induction xs; simpl; auto.
     repeat break_match.
     - apply IHxs.
@@ -72,7 +72,7 @@ Section dedup.
     forall xs (x : A),
       In x (dedup xs) ->
       In x xs.
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *.
     - intuition.
     - break_if; simpl in *; intuition.
@@ -81,7 +81,7 @@ Section dedup.
   Lemma NoDup_dedup :
     forall (xs : list A),
       NoDup (dedup xs).
-  Proof.
+  Proof using.
     induction xs; simpl.
     - constructor.
     - break_if; auto.
@@ -94,7 +94,7 @@ Section dedup.
   Lemma remove_dedup_comm : forall (x : A) xs,
       remove A_eq_dec x (dedup xs) =
       dedup (remove A_eq_dec x xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl. repeat (break_match; simpl); auto using f_equal.
@@ -106,7 +106,7 @@ Section dedup.
     forall xs (p : A) ys xs' ys',
       dedup (xs ++ p :: ys) = xs' ++ p :: ys' ->
       remove A_eq_dec p (dedup (xs ++ ys)) = xs' ++ ys'.
-  Proof.
+  Proof using.
     intros xs p ys xs' ys' H.
     f_apply H (remove A_eq_dec p).
     rewrite remove_dedup_comm, remove_partition in *.
@@ -121,7 +121,7 @@ Section dedup.
 
   Lemma dedup_NoDup_id : forall (xs : list A),
       NoDup xs -> dedup xs = xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl. invc_NoDup. concludes.
@@ -132,7 +132,7 @@ Section dedup.
     forall x xs,
       (~ In x xs) ->
       x :: dedup xs = dedup (x :: xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl in *. intuition. repeat break_match; intuition.

--- a/FilterMap.v
+++ b/FilterMap.v
@@ -23,7 +23,7 @@ Section filter_map.
                                                  | Some y => Some (g y)
                                                  | None => None
                                                  end) l.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *.
     - auto.
     - repeat break_match; simpl; auto using f_equal.
@@ -33,7 +33,7 @@ Section filter_map.
     forall (f g : A -> option B) l,
       (forall x, f x = g x) ->
       filterMap f l = filterMap g l.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *.
     - auto.
     - repeat find_higher_order_rewrite; auto.
@@ -45,7 +45,7 @@ Section filter_map.
                              | Some y => y :: filterMap f xs
                              | None => filterMap f xs
                              end.
-  Proof.
+  Proof using.
     simpl. auto.
   Qed.
 
@@ -54,7 +54,7 @@ Section filter_map.
       In b (filterMap f xs) ->
       exists a,
         In a xs /\ f a = Some b.
-  Proof.
+  Proof using.
     intros.
     induction xs; simpl in *; intuition.
     break_match.
@@ -66,7 +66,7 @@ Section filter_map.
   Lemma filterMap_app :
     forall (f : A -> option B) xs ys,
       filterMap f (xs ++ ys) = filterMap f xs ++ filterMap f ys.
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; repeat break_match; simpl in *; intuition auto using f_equal.
   Qed.
 
@@ -75,7 +75,7 @@ Section filter_map.
       f a = Some b ->
       In a xs ->
       In b (filterMap f xs).
-  Proof.
+  Proof using.
     induction xs; simpl; repeat break_match; simpl; intuition (auto; try congruence).
   Qed.
 
@@ -86,7 +86,7 @@ Section filter_map.
                          | Some b => f b
                          | None => None
                          end) xs.
-  Proof.
+  Proof using.
     induction xs; simpl; intuition.
     repeat break_match; simpl; repeat find_rewrite; auto.
   Qed.
@@ -95,7 +95,7 @@ Section filter_map.
     forall (f : A -> option B) xs,
       (forall x, In x xs -> f x = None) ->
       filterMap f xs = [].
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition.
     rewrite H; auto.
   Qed.
@@ -108,7 +108,7 @@ Section filter_map.
           x1 = x2) ->
       NoDup l ->
       NoDup (filterMap f l).
-  Proof.
+  Proof using.
     induction l; intros.
     - constructor.
     - simpl. invc_NoDup.

--- a/ListUtil.v
+++ b/ListUtil.v
@@ -45,7 +45,7 @@ Section list_util.
       x <> y ->
       In y xs ->
       In y (remove A_eq_dec x xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - intuition.
     - simpl in *.
@@ -57,7 +57,7 @@ Section list_util.
     forall (x y : A) xs,
       In y (remove A_eq_dec x xs) ->
       In y xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl in *. break_if; simpl in *; intuition.
@@ -66,7 +66,7 @@ Section list_util.
   Lemma remove_partition :
     forall xs (p : A) ys,
       remove A_eq_dec p (xs ++ p :: ys) = remove A_eq_dec p (xs ++ ys).
-  Proof.
+  Proof using.
     induction xs; intros; simpl; break_if; congruence.
   Qed.
 
@@ -74,13 +74,13 @@ Section list_util.
     forall (x : A) xs,
       ~ In x xs ->
       remove A_eq_dec x xs = xs.
-  Proof.
+  Proof using.
     intros. induction xs; simpl in *; try break_if; intuition congruence.
   Qed.
 
   Lemma filter_app : forall (f : A -> bool) xs ys,
       filter f (xs ++ ys) = filter f xs ++ filter f ys.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl. rewrite IHxs. break_if; auto.
@@ -89,7 +89,7 @@ Section list_util.
   Lemma filter_fun_ext_eq : forall f g xs,
       (forall a : A, In a xs -> f a = g a) ->
       filter f xs = filter g xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl. rewrite H by intuition. rewrite IHxs by intuition. auto.
@@ -99,7 +99,7 @@ Section list_util.
       (forall x y, In x xs -> In y xs ->
               f x = f y -> x = y) ->
       NoDup xs -> NoDup (map f xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - constructor.
     - simpl. invc_NoDup. constructor.
@@ -115,7 +115,7 @@ Section list_util.
       NoDup l' ->
       (forall a, In a l -> ~ In a l') ->
       NoDup (l ++ l').
-  Proof.
+  Proof using.
     induction l; intros.
     - auto.
     - simpl. invc_NoDup. constructor.
@@ -127,7 +127,7 @@ Section list_util.
     forall p (l : list A),
       NoDup l ->
       NoDup (filter p l).
-  Proof.
+  Proof using.
     induction l; intros.
     - auto.
     - invc_NoDup. simpl. break_if; auto.
@@ -139,7 +139,7 @@ Section list_util.
     forall (f : A -> B) g l,
       NoDup (map f l) ->
       NoDup (map f (filter g l)).
-  Proof.
+  Proof using.
     intros. induction l; simpl in *.
     - constructor.
     - invc_NoDup. concludes.
@@ -154,7 +154,7 @@ Section list_util.
   Lemma filter_true_id : forall (f : A -> bool) xs,
       (forall x, In x xs -> f x = true) ->
       filter f xs = xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl. now rewrite H, IHxs by intuition.
@@ -162,7 +162,7 @@ Section list_util.
 
   Lemma map_of_map : forall (f : A -> B) (g : B -> C) xs,
       map g (map f xs) = map (fun x => g (f x)) xs.
-  Proof.
+  Proof using.
     induction xs; simpl; auto using f_equal2.
   Qed.
 
@@ -172,7 +172,7 @@ Section list_util.
             f y = g y) ->
       g x = false ->
       filter f (remove A_eq_dec x xs) = filter g xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl.
@@ -185,7 +185,7 @@ Section list_util.
   Lemma flat_map_nil : forall (f : A -> list B) l,
       flat_map f l = [] ->
       l = [] \/ (forall x, In x l -> f x = []).
-  Proof.
+  Proof using.
     induction l; intros.
     - intuition.
     - right. simpl in *.
@@ -198,7 +198,7 @@ Section list_util.
       NoDup l ->
       Permutation l l' ->
       NoDup l'.
-  Proof.
+  Proof using.
     intros l l' Hnd Hp.
     induction Hp; auto; invc_NoDup; constructor;
       eauto using Permutation_in, Permutation_sym;
@@ -208,7 +208,7 @@ Section list_util.
   Theorem NoDup_append :
     forall l (a : A),
       NoDup (l ++ [a]) <-> NoDup (a :: l).
-  Proof. 
+  Proof using. 
     intuition eauto using NoDup_Permutation_NoDup, Permutation_sym, Permutation_cons_append.
   Qed.
 
@@ -219,7 +219,7 @@ Section list_util.
       In x xs ->
       In y xs ->
       x = y.
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *.
     - intuition.
     - invc_NoDup. intuition; subst; auto; exfalso.
@@ -230,7 +230,7 @@ Section list_util.
   Lemma remove_length_not_in : forall (x : A) xs,
       ~ In x xs ->
       length (remove A_eq_dec x xs) = length xs.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl in *. intuition.
@@ -241,7 +241,7 @@ Section list_util.
       In x xs ->
       NoDup xs ->
       S (length (remove A_eq_dec x xs)) = length xs.
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition; invc_NoDup;
       break_if; subst; intuition (simpl; try congruence).
     now rewrite remove_length_not_in.
@@ -255,7 +255,7 @@ Section list_util.
         (forall x : A, In x xs -> In x ys) ->
         length xs = length ys ->
         (forall x, In x ys -> In x xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - destruct ys; simpl in *; congruence.
     - invc_NoDup. concludes.
@@ -287,7 +287,7 @@ Section list_util.
     forall (x : A) xs,
       NoDup xs ->
       NoDup (remove A_eq_dec x xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto with struct_util.
     - invc_NoDup. simpl. break_if; eauto 6 using in_remove with struct_util.
@@ -296,7 +296,7 @@ Section list_util.
   Lemma remove_length_ge : forall (x : A) xs,
       NoDup xs ->
       length (remove A_eq_dec x xs) >= length xs - 1.
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - invc_NoDup. simpl. break_if.
@@ -309,7 +309,7 @@ Section list_util.
   Lemma remove_length_le :
     forall (x : A) xs eq_dec,
       length xs >= length (remove eq_dec x xs).
-  Proof.
+  Proof using.
     induction xs; intros.
     - auto.
     - simpl in *.
@@ -321,7 +321,7 @@ Section list_util.
     forall (x : A) xs eq_dec,
       In x xs ->
       length xs > length (remove eq_dec x xs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *; intuition.
     - subst.
       break_if; try congruence.
@@ -336,7 +336,7 @@ Section list_util.
       NoDup xs ->
       (forall x : A, In x xs -> In x ys) ->
       length ys >= length xs.
-  Proof.
+  Proof using Type*.
     induction xs; intros.
     - simpl. omega.
     - specialize (IHxs (remove A_eq_dec a ys)).
@@ -358,7 +358,7 @@ Section list_util.
     forall xs (y : A) zs w,
       xs ++ y :: zs = [w] ->
       xs = [] /\ y = w /\ zs = [].
-  Proof.
+  Proof using.
     intros.
     destruct xs.
     - solve_by_inversion.
@@ -369,7 +369,7 @@ Section list_util.
     forall (l : list A) xs a ys,
       l = xs ++ a :: ys ->
       In a l.
-  Proof.
+  Proof using.
     intros. subst. auto with *.
   Qed.
   Hint Resolve app_cons_in : struct_util.
@@ -379,7 +379,7 @@ Section list_util.
       l = xs ++ a :: ys ->
       In b (xs ++ ys) ->
       In b l.
-  Proof.
+  Proof using.
     intros. subst. in_crush.
   Qed.
   Hint Resolve app_cons_in_rest : struct_util.
@@ -387,7 +387,7 @@ Section list_util.
   Lemma remove_filter_commute :
     forall (l : list A) A_eq_dec f x,
       remove A_eq_dec x (filter f l) = filter f (remove A_eq_dec x l).
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; auto.
     repeat (break_if; subst; simpl in *; try congruence).
   Qed.
@@ -396,7 +396,7 @@ Section list_util.
     forall (f : A -> bool) x l l',
       filter f l = l' ->
       In x l' -> In x l.
-  Proof.
+  Proof using.
     intros. subst.
     eapply filter_In; eauto.
   Qed.
@@ -406,7 +406,7 @@ Section list_util.
       NoDup (l1 ++ x :: l2) ->
       filter f (l1 ++ x :: l2) = (l1' ++ x :: l2') ->
       filter f l1 = l1' /\ filter f l2 = l2'.
-  Proof.
+  Proof using.
     induction l1; intros; simpl in *; break_if; simpl in *; invc_NoDup.
     - destruct l1'; simpl in *.
       + solve_by_inversion.
@@ -424,7 +424,7 @@ Section list_util.
       (forall b, f (g b) = b) ->
       lb = map f la ->
       la = map g lb.
-  Proof.
+  Proof using.
     destruct la; intros; simpl in *.
     - subst. reflexivity.
     - destruct lb; try congruence.
@@ -441,7 +441,7 @@ Section list_util.
       In(A:=A) x l ->
       ~ In(A:=A) y l ->
       x <> y.
-  Proof.
+  Proof using.
     intuition congruence.
   Qed.
 
@@ -450,7 +450,7 @@ Section list_util.
       In(A:=A) a (x :: xs) ->
       a <> x ->
       In a xs.
-  Proof.
+  Proof using.
     simpl.
     intuition congruence.
   Qed.
@@ -460,7 +460,7 @@ Section list_util.
       NoDup (xs ++ ys ++ b :: zs) ->
       In b xs ->
       False.
-  Proof.
+  Proof using.
     intros.
     rewrite <- app_ass in *.
     find_apply_lem_hyp NoDup_remove.
@@ -473,7 +473,7 @@ Section list_util.
       NoDup (xs ++ ys ++ b :: zs) ->
       In b ys ->
       False.
-  Proof.
+  Proof using.
     intros.
     rewrite <- app_ass in *.
     find_apply_lem_hyp NoDup_remove_2.
@@ -486,7 +486,7 @@ Section list_util.
       NoDup (xs ++ ys ++ b :: zs) ->
       In b zs ->
       False.
-  Proof.
+  Proof using.
     intros.
     rewrite <- app_ass in *.
     find_apply_lem_hyp NoDup_remove_2.
@@ -498,7 +498,7 @@ Section list_util.
     forall xs ys zs x y a,
       In (A:=A) a (xs ++ ys ++ zs) ->
       In a (xs ++ x :: ys ++ y :: zs).
-  Proof.
+  Proof using.
     intros.
     repeat (do_in_app; intuition auto 10 with *).
   Qed.
@@ -509,7 +509,7 @@ Section list_util.
       a <> x ->
       a <> y ->
       In a (xs ++ ys ++ zs).
-  Proof.
+  Proof using.
     intros.
     repeat (do_in_app; simpl in *; intuition (auto with *; try congruence)).
   Qed.
@@ -519,7 +519,7 @@ Section list_util.
       In (A:=A) a (xs ++ y :: zs) ->
       a <> y ->
       In a (xs ++ zs).
-  Proof.
+  Proof using.
     intros.
     do_in_app; simpl in *; intuition. congruence.
   Qed.
@@ -528,7 +528,7 @@ Section list_util.
     forall a xs y zs,
       In (A:=A) a (xs ++ zs) ->
       In a (xs ++ y :: zs).
-  Proof.
+  Proof using.
     intros.
     do_in_app; simpl in *; intuition.
   Qed.
@@ -537,7 +537,7 @@ Section list_util.
     forall l,
       NoDup (A:=A) l ->
       NoDup (rev l).
-  Proof.
+  Proof using.
     induction l; intros; simpl.
     - auto.
     - apply NoDup_append.
@@ -553,7 +553,7 @@ Section list_util.
       (forall x y, In x xs -> In y xs -> f x = f y -> g x = g y) ->
       NoDup (map g xs) ->
       NoDup (map f xs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *.
     - constructor.
     - invc_NoDup.
@@ -574,7 +574,7 @@ Section list_util.
       NoDup sub2 ->
       length sub1 + length sub2 > length l ->
       exists a, In a sub1 /\ In a sub2.
-  Proof.
+  Proof using Type*.
     induction l.
     intros.
     + simpl in *. find_apply_lem_hyp plus_gt_0. intuition.
@@ -606,7 +606,7 @@ Section list_util.
   Lemma snoc_assoc :
     forall (l : list A) x y,
       l ++ [x; y] = (l ++ [x]) ++ [y].
-  Proof.
+  Proof using.
     induction l; intros; simpl; intuition.
     auto using f_equal.
   Qed.
@@ -614,7 +614,7 @@ Section list_util.
   Lemma cons_cons_app :
     forall (x y : A),
       [x; y] = [x] ++ [y].
-  Proof.
+  Proof using.
     auto.
   Qed.
 
@@ -625,7 +625,7 @@ Section list_util.
         l = l1 ++ l2 /\
         map f l1 = xs /\
         map f l2 = ys.
-  Proof.
+  Proof using.
     induction l; simpl; intros xs ys H.
     - symmetry in H. apply app_eq_nil in H. break_and. subst.
       exists [], []. auto.
@@ -647,7 +647,7 @@ Section list_util.
         map f ap = p /\
         f a = x /\
         map f ap' = p'.
-  Proof.
+  Proof using.
     intros p l x p' f H_m.
     pose proof map_eq_inv f _ _ _ H_m.
     break_exists_name l1.
@@ -666,14 +666,14 @@ Section list_util.
     forall (f : A -> B),
       (forall a a', f a = f a' -> a = a') ->
       forall l l', map f l = map f l' -> l = l'.
-  Proof.
+  Proof using.
     induction l; simpl; intros l' Heq; destruct l'; simpl in *; try congruence.
     find_inversion. auto using f_equal2.
   Qed.
 
   Lemma map_fst_snd_id :
     forall l, map (fun t : A * B => (fst t, snd t)) l = l.
-  Proof.
+  Proof using.
     intros.
     rewrite <- map_id.
     apply map_ext.
@@ -682,14 +682,14 @@ Section list_util.
 
   Lemma in_firstn : forall n (x : A) xs,
       In x (firstn n xs) -> In x xs.
-  Proof.
+  Proof using.
     induction n; simpl; intuition; break_match; simpl in *; intuition.
   Qed.
 
   Lemma firstn_NoDup : forall n (xs : list A),
       NoDup xs ->
       NoDup (firstn n xs).
-  Proof.
+  Proof using.
     induction n; intros; simpl; destruct xs; auto with struct_util.
     invc_NoDup.
     eauto 6 using in_firstn with struct_util.

--- a/Nth.v
+++ b/Nth.v
@@ -15,7 +15,7 @@ Section nth.
     forall n l (x : A),
       nth_error l n = Some x ->
       Nth l n x.
-  Proof.
+  Proof using.
     induction n; intros; simpl in *; auto.
     - break_match; try discriminate.
       unfold value in *.
@@ -30,7 +30,7 @@ Section nth.
     forall n l (x : A),
       Nth l n x ->
       nth_error l n = Some x.
-  Proof.
+  Proof using.
     intros.
     induction H; simpl in *; auto.
   Qed.

--- a/Prefix.v
+++ b/Prefix.v
@@ -18,7 +18,7 @@ Section prefix.
     forall (l : list A),
       Prefix l [] ->
       l = [].
-  Proof.
+  Proof using.
     intros. destruct l.
     - reflexivity.
     - contradiction.
@@ -28,7 +28,7 @@ Section prefix.
     forall (l l' : list A) a,
       Prefix l' l ->
       Prefix (a :: l') (a :: l).
-  Proof.
+  Proof using.
     simpl. intuition.
   Qed.
 
@@ -36,7 +36,7 @@ Section prefix.
     forall (l l' : list A),
       Prefix l' l ->
       (forall x, In x l' -> In x l).
-  Proof.
+  Proof using.
     induction l; intros l' H.
     - find_apply_lem_hyp Prefix_nil. subst. contradiction.
     - destruct l'.
@@ -49,7 +49,7 @@ Section prefix.
     forall (xs ys zs : list A),
       xs ++ ys = zs ->
       Prefix xs zs.
-  Proof.
+  Proof using.
     induction xs; intros; simpl in *.
     - auto.
     - break_match.
@@ -62,7 +62,7 @@ Section prefix.
       Prefix l l' ->
       In x l ->
       In x l'.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition;
       subst; break_match; intuition; subst; intuition.
   Qed.

--- a/PropUtil.v
+++ b/PropUtil.v
@@ -45,38 +45,38 @@ Variables
 
 Lemma equates_0 : forall(P Q:Prop),
   P -> P = Q -> Q.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_1 :
   forall(P:A0->Prop) x1 y1,
   P y1 -> x1 = y1 -> P x1.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_2 :
   forall y1 (P:A0->forall(x1:A1),Prop) x1 x2,
   P y1 x2 -> x1 = y1 -> P x1 x2.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_3 :
   forall y1 (P:A0->forall(x1:A1)(x2:A2 x1),Prop) x1 x2 x3,
   P y1 x2 x3 -> x1 = y1 -> P x1 x2 x3.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_4 :
   forall y1 (P:A0->forall(x1:A1)(x2:A2 x1)(x3:A3 x2),Prop) x1 x2 x3 x4,
   P y1 x2 x3 x4 -> x1 = y1 -> P x1 x2 x3 x4.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_5 :
   forall y1 (P:A0->forall(x1:A1)(x2:A2 x1)(x3:A3 x2)(x4:A4 x3),Prop) x1 x2 x3 x4 x5,
   P y1 x2 x3 x4 x5 -> x1 = y1 -> P x1 x2 x3 x4 x5.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 Lemma equates_6 :
   forall y1 (P:A0->forall(x1:A1)(x2:A2 x1)(x3:A3 x2)(x4:A4 x3)(x5:A5 x4),Prop)
   x1 x2 x3 x4 x5 x6,
   P y1 x2 x3 x4 x5 x6 -> x1 = y1 -> P x1 x2 x3 x4 x5 x6.
-Proof. intros. subst. auto. Qed.
+Proof using. intros. subst. auto. Qed.
 
 End equatesLemma.
 

--- a/RemoveAll.v
+++ b/RemoveAll.v
@@ -20,7 +20,7 @@ Section remove_all.
     forall ds l x,
       In x (remove_all ds l) ->
       In x l.
-  Proof.
+  Proof using.
     induction ds; intros; simpl in *; intuition.
     eauto using in_remove.
   Qed.
@@ -30,7 +30,7 @@ Section remove_all.
       ~ In x ds ->
       In x l ->
       In x (remove_all ds l).
-  Proof.
+  Proof using.
     induction ds; intros; simpl in *; intuition auto using remove_preserve.
   Qed.
 
@@ -39,7 +39,7 @@ Section remove_all.
       In x (remove_all ds l) ->
       In x ds ->
       False.
-  Proof.
+  Proof using.
     induction ds; intros; simpl in *; intuition.
     - subst. find_apply_lem_hyp in_remove_all_was_in.
       eapply remove_In; eauto.
@@ -49,7 +49,7 @@ Section remove_all.
   Lemma remove_all_nil :
     forall ys,
       remove_all ys [] = [].
-  Proof.
+  Proof using.
     intros. induction ys; simpl in *; intuition.
   Qed.
 
@@ -59,7 +59,7 @@ Section remove_all.
        In a ys) \/
       (remove_all ys (a :: l) = a :: (remove_all ys l) /\
        ~In a ys).
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *; intuition.
     break_if; subst; simpl in *; intuition.
     specialize (IHys a0 (remove A_eq_dec a l)). intuition.
@@ -70,7 +70,7 @@ Section remove_all.
       before x y (remove_all ys l) ->
       ~ In y ys ->
       before x y l.
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition.
     - rewrite remove_all_nil in *. simpl in *. intuition.
     - pose proof remove_all_cons ys a l. intuition.
@@ -84,7 +84,7 @@ Section remove_all.
       before x y l ->
       ~ In x xs ->
       before x y (remove_all xs l).
-  Proof.
+  Proof using.
     induction l; intros; simpl in *; intuition;
       pose proof remove_all_cons xs a l; subst; intuition;
         repeat find_rewrite; simpl in *; intuition.

--- a/Subseq.v
+++ b/Subseq.v
@@ -20,7 +20,7 @@ Section subseq.
   Hypothesis A_eq_dec : forall x y : A, {x = y} + {x <> y}.
 
   Lemma subseq_refl : forall (l : list A), subseq l l.
-  Proof.
+  Proof using.
     induction l; simpl; tauto.
   Qed.
 
@@ -29,7 +29,7 @@ Section subseq.
       subseq xs ys ->
       subseq ys zs ->
       subseq xs zs.
-  Proof.
+  Proof using.
     induction zs; intros; simpl in *;
       repeat break_match; subst; simpl in *; intuition; subst; eauto;
         right; (eapply IHzs; [|eauto]); simpl; eauto.
@@ -40,7 +40,7 @@ Section subseq.
       subseq xs ys ->
       In x xs ->
       In x ys.
-  Proof.
+  Proof using.
     induction ys; intros.
     - destruct xs; simpl in *; intuition.
     - simpl in *. break_match; simpl in *; intuition; subst; intuition eauto;
@@ -52,7 +52,7 @@ Section subseq.
       subseq xs ys ->
       NoDup ys ->
       NoDup xs.
-  Proof.
+  Proof using.
     induction ys; intros.
     - destruct xs; simpl in *; intuition.
     - simpl in *. invc_NoDup.
@@ -65,7 +65,7 @@ Section subseq.
   Lemma subseq_remove :
     forall (x : A) xs,
       subseq (remove A_eq_dec x xs) xs.
-  Proof.
+  Proof using.
     induction xs; intros; simpl.
     - auto.
     - repeat break_match; auto.
@@ -77,7 +77,7 @@ Section subseq.
     forall (f : A -> B) ys xs,
       subseq xs ys ->
       subseq (map f xs) (map f ys).
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *.
     - repeat break_match; try discriminate; auto.
     - repeat break_match; try discriminate; auto.
@@ -89,7 +89,7 @@ Section subseq.
   Lemma subseq_cons_drop :
     forall xs ys (a : A),
       subseq (a :: xs) ys -> subseq xs ys.
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *; intuition; break_match; eauto.
   Qed.
 
@@ -97,7 +97,7 @@ Section subseq.
     forall (ys xs : list A),
       subseq xs ys ->
       length xs <= length ys.
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *; break_match; intuition.
     subst. simpl in *. specialize (IHys l). concludes. auto with *.
   Qed.
@@ -107,7 +107,7 @@ Section subseq.
       subseq xs ys ->
       subseq ys xs ->
       xs = ys.
-  Proof.
+  Proof using.
     induction xs; intros; destruct ys; simpl in *;
       intuition eauto using f_equal2, subseq_cons_drop.
     exfalso.
@@ -118,7 +118,7 @@ Section subseq.
   Lemma subseq_filter :
     forall (f : A -> bool) xs,
       subseq (filter f xs) xs.
-  Proof.
+  Proof using.
     induction xs; intros; simpl.
     - auto.
     - repeat break_match; intuition congruence.
@@ -127,7 +127,7 @@ Section subseq.
   Lemma subseq_nil :
     forall xs,
       subseq (A:=A) [] xs.
-  Proof.
+  Proof using.
     destruct xs; simpl; auto.
   Qed.
 
@@ -135,7 +135,7 @@ Section subseq.
     forall a xs ys,
       subseq(A:=A) xs ys ->
       subseq xs (a :: ys).
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *; repeat break_match; intuition.
   Qed.
 
@@ -143,7 +143,7 @@ Section subseq.
     forall (f : B -> option A) ys xs,
       subseq xs ys ->
       subseq (filterMap f xs) (filterMap f ys).
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *; repeat break_match; auto; try discriminate; intuition; subst.
     - simpl. find_rewrite. auto.
     - auto using subseq_skip.
@@ -154,7 +154,7 @@ Section subseq.
   Lemma subseq_app_r :
     forall xs ys,
       subseq (A:=A) ys (xs ++ ys).
-  Proof.
+  Proof using.
     induction xs; intros; simpl.
     + auto using subseq_refl.
     + break_match.
@@ -166,7 +166,7 @@ Section subseq.
     forall ys xs zs,
       subseq (A:=A) xs ys ->
       subseq (xs ++ zs) (ys ++ zs).
-  Proof.
+  Proof using.
     induction ys; intros; simpl in *.
     - break_match; intuition auto using subseq_refl.
     - repeat break_match.
@@ -181,21 +181,21 @@ Section subseq.
     forall xs ys zs,
       subseq (A:=A) ys zs ->
       subseq (A:=A) (xs ++ ys) (xs ++ zs).
-  Proof.
+  Proof using.
     induction xs; intros; simpl; intuition.
   Qed.
 
   Lemma subseq_2_3 :
     forall xs ys zs x y,
       subseq(A:=A) (xs ++ ys ++ zs) (xs ++ x :: ys ++ y :: zs).
-  Proof.
+  Proof using.
     auto using subseq_refl, subseq_skip, subseq_app_head.
   Qed.
 
   Lemma subseq_middle :
     forall xs y zs,
       subseq (A:=A) (xs ++ zs) (xs ++ y :: zs).
-  Proof.
+  Proof using.
     intros.
     apply subseq_app_head.
     apply subseq_skip.
@@ -206,7 +206,7 @@ Section subseq.
     forall (ds l l' : list A),
       subseq l l' ->
       subseq (remove_all A_eq_dec ds l) l'.
-  Proof.
+  Proof using.
     induction ds; intros; simpl.
     - auto.
     - apply IHds.

--- a/Update.v
+++ b/Update.v
@@ -12,7 +12,7 @@ Section update.
     forall (sigma : A -> B) x v y,
       x <> y ->
       update A_eq_dec sigma x v y = sigma y.
-  Proof.
+  Proof using.
     unfold update.
     intros.
     break_if; congruence.
@@ -21,7 +21,7 @@ Section update.
   Lemma update_nop :
     forall (sigma : A -> B) x y,
       update A_eq_dec sigma x (sigma x) y = sigma y.
-  Proof.
+  Proof using.
     unfold update.
     intros. break_if; congruence.
   Qed.
@@ -30,7 +30,7 @@ Section update.
     forall (sigma : A -> B) x y v,
       x = y ->
       update A_eq_dec sigma x v y = v.
-  Proof.
+  Proof using.
     intros. subst.
     unfold update.
     break_if; congruence.
@@ -39,7 +39,7 @@ Section update.
   Lemma update_same :
     forall (sigma : A -> B) x v,
       update A_eq_dec sigma x v x = v.
-  Proof.
+  Proof using.
     intros.
     rewrite update_eq; auto.
   Qed.
@@ -47,7 +47,7 @@ Section update.
   Lemma update_nop_ext :
     forall (sigma : A -> B) h,
       update A_eq_dec sigma h (sigma h) = sigma.
-  Proof.
+  Proof using.
     intros.
     apply functional_extensionality.
     intros.
@@ -58,7 +58,7 @@ Section update.
     forall (sigma : A -> B) y v,
       sigma y = v ->
       update A_eq_dec sigma y v = sigma.
-  Proof.
+  Proof using.
     intros.
     subst.
     apply update_nop_ext.
@@ -67,7 +67,7 @@ Section update.
   Lemma update_overwrite :
     forall (sigma : A -> B) h st st',
       update A_eq_dec (update A_eq_dec sigma h st) h st' = update A_eq_dec sigma h st'.
-  Proof.
+  Proof using.
     intros.
     apply functional_extensionality.
     intros. destruct (A_eq_dec h x).


### PR DESCRIPTION
Per the [Coq manual](https://coq.inria.fr/refman/Reference-Manual031.html#sec772), proofs of lemmas inside sections cannot be processed asynchronously unless Coq knows the precise statement of the lemma. Since the section variables used are normally only determined at the end of the section, proofs inside sections must be annotated with the "Proof using" [notation](https://coq.inria.fr/refman/Reference-Manual009.html#ProofUsing) to become eligible for asynchronous processing.

In this PR, I add "Proof using" notation to all proofs inside sections in StructTact. This is potentially beneficial both when editing StructTact in editors with asynchronous processing such as Coqoon and CoqIDE, but also when regression proving StructTact in batch mode with knowledge of dependencies of changed files. To the best of my knowledge, the semantics of all annotated lemmas remains the same.

I have checked locally that the current Verdi master branch builds using these changes.
