### PR TITLE
add make task for quick compilation, adhere to Proof convention

### DIFF
--- a/ListUtil.v
+++ b/ListUtil.v
@@ -336,7 +336,7 @@ Section list_util.
       NoDup xs ->
       (forall x : A, In x xs -> In x ys) ->
       length ys >= length xs.
-  Proof using Type*.
+  Proof using A_eq_dec.
     induction xs; intros.
     - simpl. omega.
     - specialize (IHxs (remove A_eq_dec a ys)).
@@ -574,7 +574,7 @@ Section list_util.
       NoDup sub2 ->
       length sub1 + length sub2 > length l ->
       exists a, In a sub1 /\ In a sub2.
-  Proof using Type*.
+  Proof using A_eq_dec.
     induction l.
     intros.
     + simpl in *. find_apply_lem_hyp plus_gt_0. intuition.

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ endif
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
+quick: Makefile.coq
+	$(MAKE) -f Makefile.coq quick
+
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 


### PR DESCRIPTION
A top-level make task for quick compilation (`make quick`) is convenient. Also made consistent use of `Proof using` across Verdi, Verdi Raft, and StructTact.
