### PR TITLE
build InfSeqExt as Verdi dependency in travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -11,6 +11,11 @@ popd
 case $DOWNSTREAM in
 verdi)
   pushd ..
+    git clone 'http://github.com/palmskog/InfSeqExt'
+    pushd InfSeqExt
+      ./build.sh
+    popd
+
     git clone 'http://github.com/uwplse/verdi'
     pushd verdi
       ./build.sh


### PR DESCRIPTION
To build downstream in Travis, we need all their dependencies to be built.
