### PR TITLE
Do all Travis build tasks via OPAM

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -4,23 +4,14 @@ opam init --yes --no-setup
 eval $(opam config env)
 
 opam repo add coq-released https://coq.inria.fr/opam/released
+opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
+
 opam pin add coq $COQ_VERSION --yes --verbose
 
-./build.sh
+opam pin add StructTact . --yes --verbose
 
 case $DOWNSTREAM in
 verdi-raft)
-  opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
-  opam install coq-mathcomp-ssreflect.$SSREFLECT_VERSION InfSeqExt verdi-runtime --yes --verbose
-  pushd ..
-    git clone 'https://github.com/uwplse/verdi.git'
-    pushd verdi
-      StructTact_PATH=../StructTact ./build.sh
-    popd
-    git clone 'https://github.com/uwplse/verdi-raft.git'
-    pushd verdi-raft
-      StructTact_PATH=../StructTact Verdi_PATH=../verdi ./build.sh
-    popd
-  popd
+  opam install verdi-raft --yes --verbose
   ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ addons:
       - aspcud
 env:
   matrix:
-    - DOWNSTREAM=none COQ_VERSION=8.5.3 SSREFLECT_VERSION=1.6
-    - DOWNSTREAM=verdi-raft COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
+    - DOWNSTREAM=none COQ_VERSION=8.5.3
+    - DOWNSTREAM=verdi-raft COQ_VERSION=8.6
 sudo: false
 notifications:
   slack:


### PR DESCRIPTION
In Travis build, use current cloned source as basis of local OPAM package that takes place of "latest" version of package. This allows effortless downstream builds where no custom "_PATH" parameters need to be used.